### PR TITLE
Set Faraday::Response#url outside of middleware

### DIFF
--- a/lib/link_preview/http_client.rb
+++ b/lib/link_preview/http_client.rb
@@ -6,10 +6,10 @@
 # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 # of the Software, and to permit persons to whom the Software is furnished to do
 # so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,14 +20,6 @@
 
 require 'faraday'
 require 'faraday/follow_redirects'
-
-module Faraday
-  class Response
-    def url
-      finished? ? env[:url] : nil
-    end
-  end
-end
 
 module LinkPreview
   class ExtraEnv < Faraday::Middleware

--- a/lib/link_preview/http_crawler.rb
+++ b/lib/link_preview/http_crawler.rb
@@ -22,6 +22,10 @@ require 'link_preview'
 require 'link_preview/uri'
 
 module LinkPreview
+  module ResponseWithURL
+    attr_accessor :url
+  end
+
   class HTTPCrawler
     def initialize(config, options = {})
       @config = config
@@ -51,6 +55,8 @@ module LinkPreview
       uri = dequeue_by_priority(priority_order)
       with_extra_env do
         @config.http_client.get(uri).tap do |response|
+          response.extend ResponseWithURL
+          response.url = uri
           @status[uri] = response.status.to_i
         end
       end

--- a/lib/link_preview/parser.rb
+++ b/lib/link_preview/parser.rb
@@ -6,10 +6,10 @@
 # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 # of the Software, and to permit persons to whom the Software is furnished to do
 # so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
Fixes issues with relying on middleware to set `env[:url]` 
