### PR TITLE
Group OGP properties into groups before selection

### DIFF
--- a/lib/link_preview/content.rb
+++ b/lib/link_preview/content.rb
@@ -312,8 +312,10 @@ module LinkPreview
 
     def content_html_video
       return unless content_url.present?
+      width_attribute = %(width="#{content_width_scaled}") if content_width_scaled > 0
+      height_attribute = %(height="#{content_height_scaled}") if content_height_scaled > 0
       <<-EOF.strip.gsub(/\s+/, ' ').gsub(/>\s+</, '><')
-          <video width="#{content_width_scaled}" height="#{content_height_scaled}">
+          <video #{width_attribute} #{height_attribute} controls>
             <source src="#{content_url}"
                     type="#{content_type}" />
           </video>

--- a/lib/link_preview/parser.rb
+++ b/lib/link_preview/parser.rb
@@ -207,14 +207,21 @@ module LinkPreview
     end
 
     def find_meta_property_array(doc, property)
-      a = [{}]
-      i = -1
-      enum_meta_pair(doc, 'property', /\A#{Regexp.escape(property)}/).each do |pair|
-        i += 1 if pair.key == property || pair.key == "#{property}:url"
-        a[i] ||= {}
-        a[i].merge!(pair.key => pair.value)
+      [].tap do |property_array|
+        property_group = {}
+        enum_meta_pair(doc, 'property', /\A#{Regexp.escape(property)}/).each do |pair|
+          if property_array_delimiter?(property, pair) && property_group.any?
+            property_array.push(property_group.dup)
+            property_group.clear
+          end
+          property_group.merge!(pair.key => pair.value)
+        end
+        property_array.push(property_group)
       end
-      a
+    end
+
+    def property_array_delimiter?(property, pair)
+      pair.key == property || pair.key == "#{property}:url"
     end
   end
 end

--- a/lib/link_preview/parser.rb
+++ b/lib/link_preview/parser.rb
@@ -83,23 +83,27 @@ module LinkPreview
       enum_oembed_link(doc) do |link_rel|
         discovered_uris << LinkPreview::URI.parse(link_rel, @options)
       end
+
+      opengraph_image_array_first_elem = find_meta_property_array(doc, 'og:image').first
+      opengraph_video_array_first_elem = find_meta_property_array(doc, 'og:video').first
+
       {
         opengraph: {
           title: find_meta_property(doc, 'og:title'),
           description: find_meta_property(doc, 'og:description'),
-          image_secure_url: find_meta_property(doc, 'og:image:secure_url'),
-          image: find_meta_property(doc, 'og:image'),
-          image_url: find_meta_property(doc, 'og:image:url'),
+          image_secure_url: opengraph_image_array_first_elem['og:image:secure_url'],
+          image: opengraph_image_array_first_elem['og:image'],
+          image_url: opengraph_image_array_first_elem['og:image:url'],
           tag: find_meta_property(doc, 'og:tag'),
           url: find_meta_property(doc, 'og:url'),
           type: find_meta_property(doc, 'og:type'),
           site_name: find_meta_property(doc, 'og:site_name'),
-          video_secure_url: find_meta_property(doc, 'og:video:secure_url'),
-          video: find_meta_property(doc, 'og:video'),
-          video_url: find_meta_property(doc, 'og:video:url'),
-          video_type: find_meta_property(doc, 'og:video:type'),
-          video_width: find_meta_property(doc, 'og:video:width'),
-          video_height: find_meta_property(doc, 'og:video:height')
+          video_secure_url: opengraph_video_array_first_elem['og:video:secure_url'],
+          video: opengraph_video_array_first_elem['og:video'],
+          video_url: opengraph_video_array_first_elem['og:video:url'],
+          video_type: opengraph_video_array_first_elem['og:video:type'],
+          video_width: opengraph_video_array_first_elem['og:video:width'],
+          video_height: opengraph_video_array_first_elem['og:video:height']
         },
         html: {
           title: find_title(doc),
@@ -159,7 +163,7 @@ module LinkPreview
       Enumerator.new do |e|
         doc.search('head/meta').each do |node|
           next unless matching_meta_pair?(node, key, value)
-          e.yield node.attributes['content'].value
+          e.yield OpenStruct.new(key: node.attributes['property'].value, value: node.attributes['content'].value)
         end
       end
     end
@@ -168,8 +172,17 @@ module LinkPreview
       return false unless valid_meta_node?(node)
       return false unless node.attributes[key]
       return false unless node.attributes[key].value
-      return false unless node.attributes[key].value.casecmp(value.downcase).zero?
+      return false unless matching_meta_value?(node, key, value)
       true
+    end
+
+    def matching_meta_value?(node, key, value)
+      case value
+      when String
+        node.attributes[key].value.casecmp(value.downcase).zero?
+      when Regexp
+        node.attributes[key].value =~ value
+      end
     end
 
     def valid_meta_node?(node)
@@ -181,11 +194,27 @@ module LinkPreview
     end
 
     def find_meta_description(doc)
-      enum_meta_pair(doc, 'name', 'description').detect(&:present?)
+      Enumerator.new do |e|
+        doc.search('head/meta[name=description]').each do |node|
+          next unless matching_meta_pair?(node, 'name', 'description')
+          e.yield node.attributes['content'].value
+        end
+      end.first
     end
 
     def find_meta_property(doc, property)
-      enum_meta_pair(doc, 'property', property).detect(&:present?)
+      enum_meta_pair(doc, 'property', property).first.try(:value)
+    end
+
+    def find_meta_property_array(doc, property)
+      a = [{}]
+      i = -1
+      enum_meta_pair(doc, 'property', /\A#{Regexp.escape(property)}/).each do |pair|
+        i += 1 if pair.key == property || pair.key == "#{property}:url"
+        a[i] ||= {}
+        a[i].merge!(pair.key => pair.value)
+      end
+      a
     end
   end
 end

--- a/spec/files/requests/kalture_html5.yml
+++ b/spec/files/requests/kalture_html5.yml
@@ -20,10 +20,12 @@ http_interactions:
     headers:
       Server:
       - Apache/2.4.7 (Ubuntu)
+      Etag:
+      - '"2419-52c939f3d9ad5"'
+      X-N:
+      - S
       Last-Modified:
       - Thu, 25 Feb 2016 08:03:46 GMT
-      Etag:
-      - '"2419-52c939f3d9ad5-gzip"'
       Access-Control-Allow-Origin:
       - "*"
       Content-Type:
@@ -31,11 +33,11 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Cache-Control:
-      - max-age=590
+      - max-age=148
       Expires:
-      - Thu, 25 Feb 2016 18:54:31 GMT
+      - Fri, 26 Feb 2016 01:43:39 GMT
       Date:
-      - Thu, 25 Feb 2016 18:44:41 GMT
+      - Fri, 26 Feb 2016 01:41:11 GMT
       Content-Length:
       - '9241'
       Connection:
@@ -250,7 +252,7 @@ http_interactions:
         dCZxdW90OyBjb250ZW50PSZxdW90OzM3MCZxdW90OyAvJmd0OwkKPC9wcmU+
         CjwvYm9keT4KPC9odG1sPg==
     http_version: 
-  recorded_at: Thu, 25 Feb 2016 18:44:41 GMT
+  recorded_at: Fri, 26 Feb 2016 01:41:11 GMT
 - request:
     method: get
     uri: http://cdnbakmi.kaltura.com/p/243342/sp/24334200/thumbnail/entry_id/1_sf5ovm7u/version/100003/width/400
@@ -271,38 +273,40 @@ http_interactions:
     headers:
       Server:
       - nginx/1.8.0
+      Vary:
+      - Accept-Encoding
+      X-Vod-Me:
+      - pa-front-origin102
+      X-Vod-Session:
+      - '380955972'
+      Last-Modified:
+      - Sun, 19 Nov 2000 08:52:00 GMT
+      Etag:
+      - '"11092ea89-1e4f-0"'
       Content-Type:
       - image/jpeg
       Content-Length:
       - '7759'
       X-Me:
-      - pa-front-thumb2
+      - pa-front-thumb1
       X-Kaltura-Session:
-      - '890700395'
+      - '991505528'
       Pragma:
       - ''
       X-Kaltura:
       - cached-thumb-exists,19a8ef605b30ba4ada8be6b8a425ea6e
-      Last-Modified:
-      - Sun, 19 Nov 2000 08:52:00 GMT
       Accept-Ranges:
       - bytes
       Access-Control-Allow-Origin:
       - "*"
       X-Kaltura-Sendfile:
       - ''
-      Etag:
-      - '"11092ea89-1e4f-0"'
-      X-Vod-Me:
-      - pa-front-origin104
-      X-Vod-Session:
-      - '2120171211'
       Cache-Control:
-      - public, max-age=3526
+      - public, max-age=488
       Expires:
-      - Thu, 25 Feb 2016 19:43:27 GMT
+      - Fri, 26 Feb 2016 01:49:19 GMT
       Date:
-      - Thu, 25 Feb 2016 18:44:41 GMT
+      - Fri, 26 Feb 2016 01:41:11 GMT
       Connection:
       - keep-alive
     body:
@@ -482,5 +486,5 @@ http_interactions:
         chCCPWlQhCCOxQhCCD2qp3IQgqqFCEFHblQoQgW5JchCBTkp25CECXpTt6EI
         FpbtyEIKlVduQhBUb1JQhB//2Q==
     http_version: 
-  recorded_at: Thu, 25 Feb 2016 18:44:41 GMT
+  recorded_at: Fri, 26 Feb 2016 01:41:11 GMT
 recorded_with: VCR 3.0.1

--- a/spec/link_preview_spec.rb
+++ b/spec/link_preview_spec.rb
@@ -683,7 +683,7 @@ describe LinkPreview do
     end
   end
 
-  context 'kaltura with html5 response', vcr: { cassette_name: 'kalture_html5', record: :all } do
+  context 'kaltura with html5 response', vcr: { cassette_name: 'kalture_html5' } do
     let(:url) { 'http://player.kaltura.com/modules/KalturaSupport/components/share/Share.html' }
 
     it_behaves_like 'link_preview'

--- a/spec/link_preview_spec.rb
+++ b/spec/link_preview_spec.rb
@@ -683,7 +683,7 @@ describe LinkPreview do
     end
   end
 
-  context 'kaltura with html5 response', vcr: { cassette_name: 'kalture_html5' } do
+  context 'kaltura with html5 response', vcr: { cassette_name: 'kalture_html5', record: :all } do
     let(:url) { 'http://player.kaltura.com/modules/KalturaSupport/components/share/Share.html' }
 
     it_behaves_like 'link_preview'
@@ -745,9 +745,9 @@ describe LinkPreview do
           description: %(Kaltura Player: Share plugin demonstrates the ease of which social share can be configured with the kaltura player toolkit.),
           type: 'video',
           thumbnail_url: 'http://cdnbakmi.kaltura.com/p/243342/sp/24334200/thumbnail/entry_id/1_sf5ovm7u/version/100003/width/400',
-          html: %(<video width="560" height="395"><source src="https://cdnapisec.kaltura.com/p/243342/sp/24334200/embedIframeJs/uiconf_id/28685261/partner_id/243342?iframeembed=true&playerId=kaltura_player&entry_id=1_sf5ovm7u" type="video/mp4" /></video>),
-          width: 560,
-          height: 395
+          html: %(<video controls><source src="https://cdnapisec.kaltura.com/p/243342/sp/24334200/playManifest/entryId/1_sf5ovm7u/flavorId/1_d2uwy7vv/format/url/protocol/http/a.mp4" type="video/mp4" /></video>),
+          width: 0,
+          height: 0
         }
       end
     end


### PR DESCRIPTION
Currently an OGP property is extracted by selecting the first element that matches. However, in the OGP specification, [properties can be grouped together into an `Array<>`](https://developers.facebook.com/docs/reference/opengraph/object-type/video.other/).  This PR tries to align more with the OGP spec by first grouping elements together into an array, and then selecting the first group of elements.

Issues:
A URL in the specs does not currently have a `"og:video:width"` associated with it. We could render a `<video>` element with no width and let the browser fill in the default, set a configurable default width, or consider this element as invalid and try to process the `"og:video:type='html/text'"` element instead.  Processing the  `"og:video:type='html/text'"` would require us to do a GET on the `"og:video:{url,secure_url}"` and render the HTML in `Content#as_oembed` (assuming it is valid).