### PR TITLE
Validate oEmbed response

### DIFF
--- a/lib/link_preview/parser.rb
+++ b/lib/link_preview/parser.rb
@@ -152,9 +152,7 @@ module LinkPreview
 
     def parse_oembed(data)
       oembed_data = parse_oembed_data(data)
-      return {} unless oembed_data
-      return {} unless oembed_data.is_a?(Hash)
-      return {} unless oembed_data['type']
+      return {} unless oembed_data.is_a?(Hash) && oembed_data['type']
       { oembed: oembed_data.merge(url: parse_oembed_content_url(data)) }
     end
 

--- a/lib/link_preview/parser.rb
+++ b/lib/link_preview/parser.rb
@@ -48,27 +48,6 @@ module LinkPreview
       end
     end
 
-    def parse_image(data)
-      {
-        image: {
-          image_url: data.url,
-          image_data: parse_image_data(data),
-          image_content_type: data.headers[:content_type],
-          image_file_name: parse_image_file_name(data)
-        }
-      }
-    end
-
-    def parse_image_file_name(data)
-      content_disposition_filename = parse_content_disposition_filename(data)
-      if content_disposition_filename.present?
-        content_disposition_filename
-      elsif data.url
-        parsed_uri = LinkPreview::URI.parse(data.url, @options)
-        parsed_uri.path.split('/').last || parsed_uri.hostname.tr('.', '_')
-      end
-    end
-
     private
 
     def ignore_opengraph_video_type_html?
@@ -100,6 +79,27 @@ module LinkPreview
         description: find_meta_description(doc),
         tags: Array.wrap(find_rel_tags(doc))
       }
+    end
+
+    def parse_image(data)
+      {
+        image: {
+          image_url: data.url,
+          image_data: parse_image_data(data),
+          image_content_type: data.headers[:content_type],
+          image_file_name: parse_image_file_name(data)
+        }
+      }
+    end
+
+    def parse_image_file_name(data)
+      content_disposition_filename = parse_content_disposition_filename(data)
+      if content_disposition_filename.present?
+        content_disposition_filename
+      elsif data.url
+        parsed_uri = LinkPreview::URI.parse(data.url, @options)
+        parsed_uri.path.split('/').last || parsed_uri.hostname.tr('.', '_')
+      end
     end
 
     def parse_opengraph_common_data(doc)

--- a/lib/link_preview/parser.rb
+++ b/lib/link_preview/parser.rb
@@ -145,14 +145,17 @@ module LinkPreview
       )
     end
 
-    def parse_oembed(data)
-      # TODO: validate oembed response
-      { oembed: (parse_oembed_data(data) || {}).merge(url: parse_oembed_content_url(data)) }
-    end
-
     def parse_video_url_content(uri)
       url = LinkPreview::URI.parse(uri, @options)
       @config.http_client.get(url.to_s, @options)
+    end
+
+    def parse_oembed(data)
+      oembed_data = parse_oembed_data(data)
+      return {} unless oembed_data
+      return {} unless oembed_data.is_a?(Hash)
+      return {} unless oembed_data['type']
+      { oembed: oembed_data.merge(url: parse_oembed_content_url(data)) }
     end
 
     def parse_oembed_data(data)
@@ -162,6 +165,8 @@ module LinkPreview
       when /json/
         MultiJson.load(data.body)
       end
+    rescue
+      nil
     end
 
     def parse_oembed_content_url(data)

--- a/link_preview.gemspec
+++ b/link_preview.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   # Development
   s.add_development_dependency('rake')
   s.add_development_dependency('rubocop')
+  s.add_development_dependency('builder')
 
   # Testing
   s.add_development_dependency('rspec', '>= 2.9')


### PR DESCRIPTION
Fix bug related to not validating oEmbed response:
```
NoMethodError: undefined method `merge' for #<String:0x007f53ac07b730>
/gems/link_preview-0.3.1/lib/link_preview/parser.rb:150 in parse_oembed
/gems/link_preview-0.3.1/lib/link_preview/parser.rb:45 in parse
/gems/link_preview-0.3.1/lib/link_preview/content.rb:270 in extract
/gems/link_preview-0.3.1/lib/link_preview/content.rb:97 in block (2 levels) in <class:Content>
/gems/link_preview-0.3.1/lib/link_preview/content.rb:278 in block in extract_all
/gems/link_preview-0.3.1/lib/link_preview/content.rb:277 in each
/gems/link_preview-0.3.1/lib/link_preview/content.rb:277 in extract_all
/gems/link_preview-0.3.1/lib/link_preview/content.rb:103 in found?
```