### PR TITLE
relax faraday dependency

### DIFF
--- a/lib/link_preview/version.rb
+++ b/lib/link_preview/version.rb
@@ -19,5 +19,5 @@
 # SOFTWARE.
 
 module LinkPreview
-  VERSION = '0.3.5'.freeze
+  VERSION = '0.3.6'.freeze
 end

--- a/link_preview.gemspec
+++ b/link_preview.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('ruby-oembed')
   s.add_dependency('addressable')
-  s.add_dependency('faraday', '~> 0.9.0')
+  s.add_dependency('faraday', '~> 0.9')
   s.add_dependency('nokogiri')
   s.add_dependency('multi_json')
 


### PR DESCRIPTION
Allow updating the Faraday gem to current (0.11.0 at the time of writing).